### PR TITLE
Feat 27 토큰 응답 로직 수정

### DIFF
--- a/src/main/java/com/ko/mediate/HC/auth/application/dto/response/TokenDto.java
+++ b/src/main/java/com/ko/mediate/HC/auth/application/dto/response/TokenDto.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @JsonInclude(Include.NON_NULL)
 public class TokenDto {
-    private static final String BEARER = "Bearer ";
 
     @ApiModelProperty(name = "리프레쉬 토큰")
     private String refreshToken;
@@ -19,7 +18,7 @@ public class TokenDto {
     private String accessToken;
 
     public TokenDto(String refreshToken, String accessToken) {
-        this.refreshToken = BEARER + refreshToken;
-        this.accessToken = BEARER + accessToken;
+        this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/com/ko/mediate/HC/auth/resolver/LoginMethodArgumentResolver.java
+++ b/src/main/java/com/ko/mediate/HC/auth/resolver/LoginMethodArgumentResolver.java
@@ -2,7 +2,7 @@ package com.ko.mediate.HC.auth.resolver;
 
 import com.ko.mediate.HC.auth.annotation.LoginUser;
 import com.ko.mediate.HC.common.ErrorCode;
-import com.ko.mediate.HC.common.exception.MediateNotFoundToken;
+import com.ko.mediate.HC.common.exception.MediateNotFoundTokenException;
 import com.ko.mediate.HC.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -33,7 +33,7 @@ public class LoginMethodArgumentResolver implements HandlerMethodArgumentResolve
             throws RuntimeException {
         String authorization = webRequest.getHeader("Authorization");
         if (authorization == null) {
-            throw new MediateNotFoundToken(ErrorCode.NO_ACCESS_TOKEN);
+            throw new MediateNotFoundTokenException(ErrorCode.NO_ACCESS_TOKEN);
         }
 
         return tokenProvider.getUserInfoFromToken(authorization.substring(7));

--- a/src/main/java/com/ko/mediate/HC/common/AuthenticationExceptionUtils.java
+++ b/src/main/java/com/ko/mediate/HC/common/AuthenticationExceptionUtils.java
@@ -1,0 +1,21 @@
+package com.ko.mediate.HC.common;
+
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import javax.servlet.http.HttpServletResponse;
+
+public class AuthenticationExceptionUtils {
+
+    public static String EXCEPTION_ATTRIBUTE_KEY = "exception";
+
+    public static void setResponse(
+            HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        JsonObject json = new JsonObject();
+        response.setContentType("application/json;charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getStatus().value());
+        json.addProperty("code", errorCode.getCode());
+        json.addProperty("description", errorCode.getDescription());
+        response.getWriter().print(json);
+    }
+}

--- a/src/main/java/com/ko/mediate/HC/common/ErrorCode.java
+++ b/src/main/java/com/ko/mediate/HC/common/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
     NO_ACCOUNT_EXISTS("ERR_0014", "가입 이력이 없습니다. 회원가입을 진행해 주세요.", HttpStatus.BAD_REQUEST),
     NICKNAME_ALREADY_EXIST("ERR_0015", "이미 존재하는 닉네임입니다.", HttpStatus.BAD_REQUEST),
     UNAUTHORIZED_ACCESS("ERR_0016", "해당 작업을 수행할 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
-    NULL_PROPERTY("ERR_0017", "엔티티의 프로퍼티는 null 값을 가질 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    NULL_PROPERTY("ERR_0017", "엔티티의 프로퍼티는 null 값을 가질 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    EXPIRED_TOKEN("ERR_0018", "만료된 토큰입니다.", HttpStatus.FORBIDDEN);
 
     private final String code;
     private final String description;

--- a/src/main/java/com/ko/mediate/HC/common/exception/MediateExpiredTokenException.java
+++ b/src/main/java/com/ko/mediate/HC/common/exception/MediateExpiredTokenException.java
@@ -1,0 +1,14 @@
+package com.ko.mediate.HC.common.exception;
+
+import com.ko.mediate.HC.common.ErrorCode;
+
+public class MediateExpiredTokenException extends MediateException {
+
+    public MediateExpiredTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public MediateExpiredTokenException() {
+        super(ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/src/main/java/com/ko/mediate/HC/common/exception/MediateExpiredTokenException.java
+++ b/src/main/java/com/ko/mediate/HC/common/exception/MediateExpiredTokenException.java
@@ -1,14 +1,21 @@
 package com.ko.mediate.HC.common.exception;
 
 import com.ko.mediate.HC.common.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
 
-public class MediateExpiredTokenException extends MediateException {
+@Getter
+public class MediateExpiredTokenException extends AuthenticationException {
+
+    private ErrorCode errorCode;
 
     public MediateExpiredTokenException(ErrorCode errorCode) {
-        super(errorCode);
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
     }
 
     public MediateExpiredTokenException() {
-        super(ErrorCode.EXPIRED_TOKEN);
+        super(ErrorCode.EXPIRED_TOKEN.getDescription());
+        errorCode = ErrorCode.EXPIRED_TOKEN;
     }
 }

--- a/src/main/java/com/ko/mediate/HC/common/exception/MediateNotFoundToken.java
+++ b/src/main/java/com/ko/mediate/HC/common/exception/MediateNotFoundToken.java
@@ -1,9 +1,0 @@
-package com.ko.mediate.HC.common.exception;
-
-import com.ko.mediate.HC.common.ErrorCode;
-
-public class MediateNotFoundToken extends MediateException {
-    public MediateNotFoundToken(ErrorCode errorCode) {
-        super(errorCode);
-    }
-}

--- a/src/main/java/com/ko/mediate/HC/common/exception/MediateNotFoundTokenException.java
+++ b/src/main/java/com/ko/mediate/HC/common/exception/MediateNotFoundTokenException.java
@@ -1,0 +1,21 @@
+package com.ko.mediate.HC.common.exception;
+
+import com.ko.mediate.HC.common.ErrorCode;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class MediateNotFoundTokenException extends AuthenticationException {
+
+    private ErrorCode errorCode;
+
+    public MediateNotFoundTokenException(ErrorCode errorCode) {
+        super(errorCode.getDescription());
+        this.errorCode = errorCode;
+    }
+
+    public MediateNotFoundTokenException() {
+        super(ErrorCode.NO_ACCESS_TOKEN.getDescription());
+        this.errorCode = ErrorCode.NO_ACCESS_TOKEN;
+    }
+}

--- a/src/main/java/com/ko/mediate/HC/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ko/mediate/HC/jwt/JwtAuthenticationEntryPoint.java
@@ -1,20 +1,27 @@
 package com.ko.mediate.HC.jwt;
 
+import static com.ko.mediate.HC.common.AuthenticationExceptionUtils.EXCEPTION_ATTRIBUTE_KEY;
+import static com.ko.mediate.HC.common.AuthenticationExceptionUtils.setResponse;
+
+import com.ko.mediate.HC.common.ErrorCode;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-                         AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute(EXCEPTION_ATTRIBUTE_KEY);
+        if (errorCode == ErrorCode.EXPIRED_TOKEN) {
+            setResponse(response, errorCode);
+        } else if (errorCode == ErrorCode.NO_ACCESS_TOKEN) {
+            setResponse(response, errorCode);
+        }
     }
 }

--- a/src/main/java/com/ko/mediate/HC/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ko/mediate/HC/jwt/JwtAuthenticationEntryPoint.java
@@ -18,10 +18,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException {
         ErrorCode errorCode = (ErrorCode) request.getAttribute(EXCEPTION_ATTRIBUTE_KEY);
-        if (errorCode == ErrorCode.EXPIRED_TOKEN) {
-            setResponse(response, errorCode);
-        } else if (errorCode == ErrorCode.NO_ACCESS_TOKEN) {
-            setResponse(response, errorCode);
-        }
+        setResponse(response, errorCode);
     }
 }

--- a/src/main/java/com/ko/mediate/HC/jwt/TokenProvider.java
+++ b/src/main/java/com/ko/mediate/HC/jwt/TokenProvider.java
@@ -3,6 +3,7 @@ package com.ko.mediate.HC.jwt;
 import com.ko.mediate.HC.auth.resolver.UserInfo;
 import com.ko.mediate.HC.common.ErrorCode;
 import com.ko.mediate.HC.common.exception.MediateExpiredTokenException;
+import com.ko.mediate.HC.common.exception.MediateInvalidTokenException;
 import com.ko.mediate.HC.tutoring.application.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -108,7 +109,7 @@ public class TokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            throw new io.jsonwebtoken.security.SecurityException("잘못된 JWT 서명입니다.");
+            throw new MediateInvalidTokenException();
         } catch (ExpiredJwtException e) {
             throw new MediateExpiredTokenException();
         } catch (UnsupportedJwtException e) {

--- a/src/main/java/com/ko/mediate/HC/jwt/TokenProvider.java
+++ b/src/main/java/com/ko/mediate/HC/jwt/TokenProvider.java
@@ -1,6 +1,8 @@
 package com.ko.mediate.HC.jwt;
 
 import com.ko.mediate.HC.auth.resolver.UserInfo;
+import com.ko.mediate.HC.common.ErrorCode;
+import com.ko.mediate.HC.common.exception.MediateExpiredTokenException;
 import com.ko.mediate.HC.tutoring.application.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 
 @Component
 public class TokenProvider {
+
     private static final String AUTHORITIES_KEY = "authority";
     private static final String ACCOUNT_ID_KEY = "accountId";
     private static final String ACCOUNT_EMAIL_KEY = "accountEmail";
@@ -47,7 +50,8 @@ public class TokenProvider {
     }
 
     private String createToken(
-            Long accountId, String accountEmail, String accountNickname, List<RoleType> roles, long tokenValidityInMilliseconds) {
+            Long accountId, String accountEmail, String accountNickname, List<RoleType> roles,
+            long tokenValidityInMilliseconds) {
 
         long now = (new Date()).getTime();
         Date validity = new Date(now + tokenValidityInMilliseconds);
@@ -58,18 +62,23 @@ public class TokenProvider {
                 .claim(ACCOUNT_NICKNAME_KEY, accountNickname)
                 .claim(
                         ROLE_KEY,
-                        String.join(",", roles.stream().map(RoleType::toString).collect(Collectors.toList())))
+                        String.join(",", roles.stream().map(RoleType::toString)
+                                .collect(Collectors.toList())))
                 .signWith(key, SignatureAlgorithm.HS512)
                 .setExpiration(validity)
                 .compact();
     }
 
-    public String createAccessToken(Long accountId, String accountEmail, String accountNickname, List<RoleType> roles) {
-        return createToken(accountId, accountEmail, accountNickname, roles, this.accessTokenValidityInMilliseconds);
+    public String createAccessToken(Long accountId, String accountEmail, String accountNickname,
+            List<RoleType> roles) {
+        return createToken(accountId, accountEmail, accountNickname, roles,
+                this.accessTokenValidityInMilliseconds);
     }
 
-    public String createRefreshToken(Long accountId, String accountEmail, String accountNickname, List<RoleType> roles) {
-        return createToken(accountId, accountEmail, accountNickname, roles, this.refreshTokenValidityInMilliseconds);
+    public String createRefreshToken(Long accountId, String accountEmail, String accountNickname,
+            List<RoleType> roles) {
+        return createToken(accountId, accountEmail, accountNickname, roles,
+                this.refreshTokenValidityInMilliseconds);
     }
 
     public UserInfo getUserInfoFromToken(String token) {
@@ -101,7 +110,7 @@ public class TokenProvider {
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             throw new io.jsonwebtoken.security.SecurityException("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            throw new ExpiredJwtException(null, null, "만료된 JWT 토큰입니다.");
+            throw new MediateExpiredTokenException();
         } catch (UnsupportedJwtException e) {
             throw new UnsupportedJwtException("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
@@ -110,11 +119,12 @@ public class TokenProvider {
     }
 
     public String createAccessTokenIfExpired(
-            String token, Long accountId, String accountEmail, String accountNickname, List<RoleType> roles) {
+            String token, Long accountId, String accountEmail, String accountNickname,
+            List<RoleType> roles) {
         try {
             validateToken(token);
             return token;
-        } catch (ExpiredJwtException e) {
+        } catch (MediateExpiredTokenException e) {
             return createAccessToken(accountId, accountEmail, accountNickname, roles);
         }
     }

--- a/src/test/java/com/ko/mediate/HC/auth/TokenProviderTest.java
+++ b/src/test/java/com/ko/mediate/HC/auth/TokenProviderTest.java
@@ -1,16 +1,15 @@
 package com.ko.mediate.HC.auth;
 
-import com.ko.mediate.HC.auth.resolver.UserInfo;
-import com.ko.mediate.HC.jwt.TokenProvider;
-import com.ko.mediate.HC.tutoring.application.RoleType;
-import io.jsonwebtoken.ExpiredJwtException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ko.mediate.HC.auth.resolver.UserInfo;
+import com.ko.mediate.HC.common.exception.MediateExpiredTokenException;
+import com.ko.mediate.HC.jwt.TokenProvider;
+import com.ko.mediate.HC.tutoring.application.RoleType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 @DisplayName("토큰 생성 Bean 테스트")
 public class TokenProviderTest {
@@ -38,7 +37,7 @@ public class TokenProviderTest {
         String expiredToken =
                 expiredTokenProvider.createAccessToken(1L, "test@naver.com", "test", List.of(role));
         assertThatThrownBy(() -> tokenProvider.validateToken(expiredToken))
-                .isInstanceOf(ExpiredJwtException.class);
+                .isInstanceOf(MediateExpiredTokenException.class);
     }
 
     @DisplayName("리프레쉬 토큰 만료 테스트")
@@ -49,7 +48,7 @@ public class TokenProviderTest {
         String expiredToken =
                 expiredTokenProvider.createRefreshToken(1L, "test@naver.com", "test", List.of(role));
         assertThatThrownBy(() -> tokenProvider.validateToken(expiredToken))
-                .isInstanceOf(ExpiredJwtException.class);
+                .isInstanceOf(MediateExpiredTokenException.class);
     }
 
     @DisplayName("유효한 토큰이면 재사용, 그렇지 않으면 생성")

--- a/src/test/java/com/ko/mediate/HC/auth/TokenProviderTest.java
+++ b/src/test/java/com/ko/mediate/HC/auth/TokenProviderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ko.mediate.HC.auth.resolver.UserInfo;
 import com.ko.mediate.HC.common.exception.MediateExpiredTokenException;
+import com.ko.mediate.HC.common.exception.MediateInvalidTokenException;
 import com.ko.mediate.HC.jwt.TokenProvider;
 import com.ko.mediate.HC.tutoring.application.RoleType;
 import java.util.List;
@@ -78,6 +79,6 @@ public class TokenProviderTest {
     void invalidTokenTest() {
         String invalidToken = "asdf1234";
         assertThatThrownBy(() -> tokenProvider.validateToken(invalidToken))
-                .isInstanceOf(io.jsonwebtoken.security.SecurityException.class);
+                .isInstanceOf(MediateInvalidTokenException.class);
     }
 }

--- a/src/test/java/com/ko/mediate/HC/auth/sign/LogoutApiTest.java
+++ b/src/test/java/com/ko/mediate/HC/auth/sign/LogoutApiTest.java
@@ -34,17 +34,17 @@ public class LogoutApiTest extends BaseApiTest {
         TokenDto dto = authService.signIn(signInDto);
 
         // when
-        mvc.perform(delete("/api/logout").header(AUTHORIZATION, dto.getAccessToken()))
+        mvc.perform(delete("/api/logout").header(AUTHORIZATION, BEARER + dto.getAccessToken()))
                 .andExpect(status().isOk());
 
         // then
         assertThat(tokenStorage.getAccessTokenById(saveId)).isNull();
         assertThat(tokenStorage.getRefreshTokenById(saveId)).isNull();
 
-        mvc.perform(delete("/api/logout").header(AUTHORIZATION, dto.getAccessToken()))
+        mvc.perform(delete("/api/logout").header(AUTHORIZATION, BEARER + dto.getAccessToken()))
                 .andExpect(status().isUnauthorized())
                 .andDo(print());
-        mvc.perform(post("/api/refresh").header("Refresh", dto.getRefreshToken()))
+        mvc.perform(post("/api/refresh").header("Refresh", BEARER + dto.getRefreshToken()))
                 .andExpect(status().isUnauthorized())
                 .andDo(print());
     }

--- a/src/test/java/com/ko/mediate/HC/common/BaseApiTest.java
+++ b/src/test/java/com/ko/mediate/HC/common/BaseApiTest.java
@@ -1,5 +1,8 @@
 package com.ko.mediate.HC.common;
 
+import static com.ko.mediate.HC.auth.AccountFactory.createAccount;
+import static com.ko.mediate.HC.auth.AccountFactory.createSignInDto;
+
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,11 +11,17 @@ import com.ko.mediate.HC.auth.application.AuthService;
 import com.ko.mediate.HC.auth.application.dto.response.TokenDto;
 import com.ko.mediate.HC.auth.domain.Account;
 import com.ko.mediate.HC.auth.infra.JpaAccountRepository;
+import com.ko.mediate.HC.communityTest.S3MockConfig;
 import com.ko.mediate.HC.config.LocalRedisConfig;
 import com.ko.mediate.HC.jwt.TokenStorage;
 import com.ko.mediate.HC.tutee.infra.JpaTuteeRepository;
 import com.ko.mediate.HC.tutor.infra.JpaTutorRepository;
 import com.ko.mediate.HC.tutoring.application.RoleType;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -26,21 +35,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.ko.mediate.HC.auth.AccountFactory.createAccount;
-import static com.ko.mediate.HC.auth.AccountFactory.createSignInDto;
-
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
 @Import({S3MockConfig.class, LocalRedisConfig.class})
 @ActiveProfiles("test")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class BaseApiTest {
+
     @Autowired
     protected JpaAccountRepository accountRepository;
     @Autowired
@@ -75,6 +76,7 @@ public class BaseApiTest {
     protected Long saveId, normalUserId;
     protected String accessToken, refreshToken;
     protected String normalAccessToken;
+    protected final String BEARER = "Bearer ";
 
     private File createTempFile() throws IOException {
         File file = new File(tempFilePath);
@@ -108,8 +110,8 @@ public class BaseApiTest {
     private void authAccounts() {
         for (Account account : accountResults) {
             TokenDto dto = authService.signIn(createSignInDto(account.getEmail(), "1234"));
-            accessTokenMap.put(account.getId(), dto.getAccessToken());
-            refreshTokenMap.put(account.getId(), dto.getRefreshToken());
+            accessTokenMap.put(account.getId(), BEARER + dto.getAccessToken());
+            refreshTokenMap.put(account.getId(), BEARER + dto.getRefreshToken());
         }
     }
 

--- a/src/test/java/com/ko/mediate/HC/communityTest/S3MockConfig.java
+++ b/src/test/java/com/ko/mediate/HC/communityTest/S3MockConfig.java
@@ -18,6 +18,7 @@ import static com.ko.mediate.HC.common.ProcessUtils.findAvailablePort;
 
 @TestConfiguration
 public class S3MockConfig {
+
     @Value("${cloud.aws.region.static}")
     private String region;
 


### PR DESCRIPTION
#27 
1. 로그인 성공 시 붙어있던 prefix를 제거했습니다.
2. 토큰 만료, 잘못된 토큰일 경우 {code:, description: }의 형태로 반환합니다.
3. 기존 필터의 로직을 리팩토링했습니다.